### PR TITLE
Test JDK > 9 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: clojure
+cache:
+  directories:
+  - $HOME/.m2
 sudo: required
 before_script:
 - ssh-keygen -N "" -f ~/.ssh/id_rsa
 - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+jdk:
+  - openjdk8
+  - openjdk11
+  - openjdk-ea

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
   directories:
   - $HOME/.m2
 sudo: required
+script: lein test-all
 before_script:
 - ssh-keygen -N "" -f ~/.ssh/id_rsa
 - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys

--- a/profiles.clj
+++ b/profiles.clj
@@ -23,7 +23,6 @@
                  "codox" ["doc"]
                  "doc" ["do" "codox," "marg"]}}
  :no-checkouts {:checkout-deps-shares ^:replace []} ; disable checkouts
- :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
  :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
  :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
  :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}

--- a/profiles.clj
+++ b/profiles.clj
@@ -23,7 +23,6 @@
                  "codox" ["doc"]
                  "doc" ["do" "codox," "marg"]}}
  :no-checkouts {:checkout-deps-shares ^:replace []} ; disable checkouts
- :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
  :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
  :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
  :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,8 @@ unprecedented level of customization."
                  [org.clojure/tools.macro "0.1.5"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/algo.monads "0.1.6"]
-                 [dda/chiba "0.2.3-SNAPSHOT"]
+                 [dda/chiba "0.2.3-SNAPSHOT" :exclusions [razum2um/bultitude]]
+                 [razum2um/bultitude "0.3.1"]
                  [com.palletops/thread-expr "1.3.0"]
                  [dda/pallet-common "0.5.0" :exclusions [org.clojure/tools.logging]]
                  [com.palletops/pallet-repl "0.8.0-beta.2"

--- a/project.clj
+++ b/project.clj
@@ -43,5 +43,5 @@ unprecedented level of customization."
                    (complement :require-no-ssh-env)}
   :deploy-repositories [["snapshots" :clojars]
                         ["releases" :clojars]]
-  :aliases {"test-all" ["with-profile" "-user,+1.10:-user,+1.9:-user,+1.8:-user,+1.7" "test"]
+  :aliases {"test-all" ["with-profile" "-user,+1.10:-user,+1.9:-user,+1.8" "test"]
             "test-latest" ["with-profile" "-user,+1.10" "test"]})

--- a/project.clj
+++ b/project.clj
@@ -17,9 +17,7 @@ unprecedented level of customization."
                  [org.clojure/tools.macro "0.1.5"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/algo.monads "0.1.6"]
-                 [com.palletops/chiba "0.2.1"]
-                 ; TODO: dda/chiba is not working jet on jdk10
-                 ;[dda/chiba "0.2.3-SNAPSHOT"]
+                 [dda/chiba "0.2.3-SNAPSHOT"]
                  [com.palletops/thread-expr "1.3.0"]
                  [dda/pallet-common "0.5.0" :exclusions [org.clojure/tools.logging]]
                  [com.palletops/pallet-repl "0.8.0-beta.2"
@@ -45,4 +43,6 @@ unprecedented level of customization."
                    ;; travis sudo is configured with !env_reset
                    (complement :require-no-ssh-env)}
   :deploy-repositories [["snapshots" :clojars]
-                        ["releases" :clojars]])
+                        ["releases" :clojars]]
+  :aliases {"test-all" ["with-profile" "-user,+1.10:-user,+1.9:-user,+1.8:-user,+1.7" "test"]
+            "test-latest" ["with-profile" "-user,+1.10" "test"]})

--- a/project.clj
+++ b/project.clj
@@ -12,8 +12,7 @@ unprecedented level of customization."
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :scm {:url "git@github.com:DomainDrivenArchitecture/pallet.git"}
 
-  :dependencies [[org.clojure/core.incubator "0.1.4"]
-                 [org.clojure/tools.logging "0.5.0-alpha"]
+  :dependencies [[org.clojure/tools.logging "0.5.0-alpha"]
                  [org.clojure/tools.macro "0.1.5"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.clojure/algo.monads "0.1.6"]

--- a/src/pallet/configure.clj
+++ b/src/pallet/configure.clj
@@ -9,7 +9,6 @@
    ~/.pallet/services/*.clj"
   (:require
    [chiba.plugin :refer [data-plugins]]
-   [clojure.core.incubator :refer [-?>]]
    [clojure.java.io :as java-io]
    [clojure.java.io :refer [resource]]
    [clojure.string :as string]

--- a/src/pallet/environment.clj
+++ b/src/pallet/environment.clj
@@ -19,7 +19,6 @@
    The merging of values between scopes is key specific, and is determined by
    `merge-key-algorithm`."
   (:require
-   [clojure.core.incubator :refer [-?>]]
    [clojure.walk :as walk]
    [pallet.core.file-upload :as file-upload]
    [pallet.ssh.node-state :as node-state]
@@ -201,5 +200,5 @@
    (maybe-update-in (select-keys environment node-keys)
                     [:phases] phases-with-meta {})
    group
-   (maybe-update-in (-?> environment :groups group)
+   (maybe-update-in (some-> environment :groups group)
                     [:phases] phases-with-meta {})))


### PR DESCRIPTION
Note, that we've already dropped `1.7` after update of `tools.cli`: https://github.com/clojure/tools.cli/pull/22

Don't merge now:
I think you can cut `[dda/chiba "0.2.3"]` containing `[razum2um/bultitude "0.3.1"]` -> I'll update this